### PR TITLE
feat: added default config from macro usage

### DIFF
--- a/src/Our.Umbraco.ImageCropPicker/Web/Controllers/ImageCropPickerApiController.cs
+++ b/src/Our.Umbraco.ImageCropPicker/Web/Controllers/ImageCropPickerApiController.cs
@@ -24,9 +24,14 @@ namespace Our.Umbraco.ImageCropPicker.Web.Controllers
                 .ToArray();
 
         [HttpGet]
-        public IEnumerable<ImageCropperConfiguration.Crop> GetImageCropsDataForDataType(int id)
+        public IEnumerable<ImageCropperConfiguration.Crop> GetImageCropsDataForDataType(string dataTypeName)
         {
-            var dataType = _dataTypeService.GetDataType(id);
+            if (string.IsNullOrWhiteSpace(dataTypeName))
+            {
+                return Enumerable.Empty<ImageCropperConfiguration.Crop>();
+            }
+
+            var dataType = _dataTypeService.GetDataType(dataTypeName);
 
             return dataType?.Configuration == null
                 ? Enumerable.Empty<ImageCropperConfiguration.Crop>()

--- a/src/Our.Umbraco.ImageCropPicker/Web/Controllers/ImageCropPickerApiController.cs
+++ b/src/Our.Umbraco.ImageCropPicker/Web/Controllers/ImageCropPickerApiController.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Web.Http;
 using Umbraco.Core;
@@ -24,14 +25,14 @@ namespace Our.Umbraco.ImageCropPicker.Web.Controllers
                 .ToArray();
 
         [HttpGet]
-        public IEnumerable<ImageCropperConfiguration.Crop> GetImageCropsDataForDataType(string dataTypeName)
+        public IEnumerable<ImageCropperConfiguration.Crop> GetImageCropsDataForDataType(Guid dataTypeKey)
         {
-            if (string.IsNullOrWhiteSpace(dataTypeName))
+            if (dataTypeKey == default(Guid))
             {
                 return Enumerable.Empty<ImageCropperConfiguration.Crop>();
             }
 
-            var dataType = _dataTypeService.GetDataType(dataTypeName);
+            var dataType = _dataTypeService.GetDataType(dataTypeKey);
 
             return dataType?.Configuration == null
                 ? Enumerable.Empty<ImageCropperConfiguration.Crop>()

--- a/src/Our.Umbraco.ImageCropPicker/Web/UI/App_Plugins/ImageCropPicker/Js/CropPicker.controller.js
+++ b/src/Our.Umbraco.ImageCropPicker/Web/UI/App_Plugins/ImageCropPicker/Js/CropPicker.controller.js
@@ -12,19 +12,19 @@
         vm.data = {};
 
         vm.init = function () {
-            var dataTypeId = '';
+            var dataTypeName = '';
 
-            if ($scope.model.config !== undefined) {
-                if ($scope.model.config.dataType !== undefined && ($scope.model.config.dataType.Id !== undefined || $scope.model.config.dataType.Id !== '')) {
-                    dataTypeId = $scope.model.config.dataType.Id;
+            if ($scope.model.config) {
+                if ($scope.model.config.dataType && $scope.model.config.dataType.Name) {
+                    dataTypeName = $scope.model.config.dataType.Name;
                 }
-                else if ($scope.model.config.dataTypeId !== undefined && $scope.model.config.dataTypeId !== '') {
-                    dataTypeId = $scope.model.config.dataTypeId;
+                else if ($scope.model.config.dataTypeName && $scope.model.config.dataTypeName !== '') {
+                    dataTypeName = $scope.model.config.dataTypeName;
                 }
             }
 
-            if ((dataTypeId !== undefined || dataTypeId !== null) && dataTypeId !== '') {
-                imageCropPickerResource.GetImageCropsDataForDataType(dataTypeId)
+            if (dataTypeName) {
+                imageCropPickerResource.GetImageCropsDataForDataType(dataTypeName)
                     .then(function (data) {
                         vm.data.cropsData = data;
                     });

--- a/src/Our.Umbraco.ImageCropPicker/Web/UI/App_Plugins/ImageCropPicker/Js/CropPicker.controller.js
+++ b/src/Our.Umbraco.ImageCropPicker/Web/UI/App_Plugins/ImageCropPicker/Js/CropPicker.controller.js
@@ -12,19 +12,19 @@
         vm.data = {};
 
         vm.init = function () {
-            var dataTypeName = '';
+            var dataTypeKey = '';
 
             if ($scope.model.config) {
-                if ($scope.model.config.dataType && $scope.model.config.dataType.Name) {
-                    dataTypeName = $scope.model.config.dataType.Name;
+                if ($scope.model.config.dataType && $scope.model.config.dataType.Key) {
+                    dataTypeKey = $scope.model.config.dataType.Key;
                 }
-                else if ($scope.model.config.dataTypeName && $scope.model.config.dataTypeName !== '') {
-                    dataTypeName = $scope.model.config.dataTypeName;
+                else if ($scope.model.config.dataTypeKey) {
+                    dataTypeKey = $scope.model.config.dataTypeKey;
                 }
             }
 
-            if (dataTypeName) {
-                imageCropPickerResource.GetImageCropsDataForDataType(dataTypeName)
+            if (dataTypeKey) {
+                imageCropPickerResource.GetImageCropsDataForDataType(dataTypeKey)
                     .then(function (data) {
                         vm.data.cropsData = data;
                     });

--- a/src/Our.Umbraco.ImageCropPicker/Web/UI/App_Plugins/ImageCropPicker/Js/CropPicker.controller.js
+++ b/src/Our.Umbraco.ImageCropPicker/Web/UI/App_Plugins/ImageCropPicker/Js/CropPicker.controller.js
@@ -10,19 +10,25 @@
         var vm = this;
 
         vm.data = {};
-        vm.value = '';
 
         vm.init = function () {
-            if ($scope.model.value !== null && $scope.model.value.alias !== null) {
-                vm.value = $scope.model.value.alias;
-            } else {
-                vm.value = '';
+            var dataTypeId = '';
+
+            if ($scope.model.config !== undefined) {
+                if ($scope.model.config.dataType !== undefined && ($scope.model.config.dataType.Id !== undefined || $scope.model.config.dataType.Id !== '')) {
+                    dataTypeId = $scope.model.config.dataType.Id;
+                }
+                else if ($scope.model.config.dataTypeId !== undefined && $scope.model.config.dataTypeId !== '') {
+                    dataTypeId = $scope.model.config.dataTypeId;
+                }
             }
 
-            imageCropPickerResource.GetImageCropsDataForDataType($scope.model.config.dataType.Id)
-                .then(function (data) {
-                    vm.data.cropsData = data;
-                });
+            if ((dataTypeId !== undefined || dataTypeId !== null) && dataTypeId !== '') {
+                imageCropPickerResource.GetImageCropsDataForDataType(dataTypeId)
+                    .then(function (data) {
+                        vm.data.cropsData = data;
+                    });
+            }
         };
 
         vm.init();

--- a/src/Our.Umbraco.ImageCropPicker/Web/UI/App_Plugins/ImageCropPicker/Js/ImageCropPicker.resource.js
+++ b/src/Our.Umbraco.ImageCropPicker/Web/UI/App_Plugins/ImageCropPicker/Js/ImageCropPicker.resource.js
@@ -23,10 +23,10 @@
                 "Failed to retrieve data types");
         }
 
-        function getImageCropsDataForDataType(id) {
+        function getImageCropsDataForDataType(dataTypeName) {
             var config = {
                 params: {
-                    id: id
+                    dataTypeName: dataTypeName
                 },
                 headers: { 'Accept': 'application/json' }
             };
@@ -36,4 +36,3 @@
         }
     };
 })();
-

--- a/src/Our.Umbraco.ImageCropPicker/Web/UI/App_Plugins/ImageCropPicker/Js/ImageCropPicker.resource.js
+++ b/src/Our.Umbraco.ImageCropPicker/Web/UI/App_Plugins/ImageCropPicker/Js/ImageCropPicker.resource.js
@@ -23,10 +23,10 @@
                 "Failed to retrieve data types");
         }
 
-        function getImageCropsDataForDataType(dataTypeName) {
+        function getImageCropsDataForDataType(dataTypeKey) {
             var config = {
                 params: {
-                    dataTypeName: dataTypeName
+                    dataTypeKey: dataTypeKey
                 },
                 headers: { 'Accept': 'application/json' }
             };

--- a/src/Our.Umbraco.ImageCropPicker/Web/UI/App_Plugins/ImageCropPicker/package.manifest
+++ b/src/Our.Umbraco.ImageCropPicker/Web/UI/App_Plugins/ImageCropPicker/package.manifest
@@ -26,7 +26,7 @@
         ]
       },
       "defaultConfig": {
-        "dataTypeId": ""
+        "dataTypeName": ""
       }
     }
   ],

--- a/src/Our.Umbraco.ImageCropPicker/Web/UI/App_Plugins/ImageCropPicker/package.manifest
+++ b/src/Our.Umbraco.ImageCropPicker/Web/UI/App_Plugins/ImageCropPicker/package.manifest
@@ -5,6 +5,7 @@
       "name": "Image Crop Picker",
       "icon": "icon-window-sizes",
       "group": "Image Cropper Extensions",
+      "isParameterEditor": false,
       "editor": {
         "view": "~/App_Plugins/ImageCropPicker/Views/CropPicker.html",
         "valueType": "JSON"
@@ -23,6 +24,9 @@
             ]
           }
         ]
+      },
+      "defaultConfig": {
+        "dataTypeId": ""
       }
     }
   ],

--- a/src/Our.Umbraco.ImageCropPicker/Web/UI/App_Plugins/ImageCropPicker/package.manifest
+++ b/src/Our.Umbraco.ImageCropPicker/Web/UI/App_Plugins/ImageCropPicker/package.manifest
@@ -26,7 +26,7 @@
         ]
       },
       "defaultConfig": {
-        "dataTypeName": ""
+        "dataTypeKey": ""
       }
     }
   ],


### PR DESCRIPTION
Added default config for macro usage + removed vm.value as we are getting view value from model.value

Example custom macro configuration:

``` json
{
  "propertyEditors": [
    {
      "alias": "Our.Umbraco.ImageCropPicker.Macro",
      "name": "Image Crop Picker (Macro)",
      "icon": "icon-window-sizes",
      "group": "Image Cropper Extensions",
      "isParameterEditor": true,
      "editor": {
        "view": "~/App_Plugins/ImageCropPicker/Views/CropPicker.html",
        "valueType": "JSON"
      },
      "prevalues": {
        "fields": [
          {
            "label": "Default config data",
            "key": "dataTypeKey",
            "view": "~/App_Plugins/ImageCropPicker/Views/CropPicker.html"
          }
        ]
      },
      "defaultConfig": {
        "dataTypeKey": "1df9f033-e6d4-451f-b8d2-e0cbc50a836f"
      }
    }
  ]
}
```

![image](https://user-images.githubusercontent.com/29370044/106588890-9dd70880-654b-11eb-8267-94a7d2a58bd7.png)


Example of MacroPartials view

``` csharp
@using Newtonsoft.Json
@using Umbraco.Core.PropertyEditors
@inherits Umbraco.Web.Macros.PartialViewMacroPage
@{
    var imageSizeMacroParameter = Model.MacroParameters["imageSize"];

    if (imageSizeMacroParameter == null
        || (imageSizeMacroParameter != null
            && string.IsNullOrWhiteSpace(imageSizeMacroParameter.ToString())))
    {
        return;
    }

    var imageSize = JsonConvert.DeserializeObject<ImageCropperConfiguration.Crop>(imageSizeMacroParameter.ToString());
}

@(imageSizeMacroParameter.ToString())

<br />

@imageSize.Alias = @imageSize.Width x @imageSize.Height
```

![image](https://user-images.githubusercontent.com/29370044/106588842-8e57bf80-654b-11eb-935a-cbe36ee7aa00.png)
