### PR TITLE
fix: v7 data type logic

### DIFF
--- a/src/Our.Umbraco.ImageCropPicker/Web/UI/App_Plugins/ImageCropPicker/Js/CropPicker.controller.js
+++ b/src/Our.Umbraco.ImageCropPicker/Web/UI/App_Plugins/ImageCropPicker/Js/CropPicker.controller.js
@@ -10,19 +10,25 @@
         var vm = this;
 
         vm.data = {};
-        vm.value = '';
 
         vm.init = function () {
-            if ($scope.model.value !== null && $scope.model.value.alias !== null) {
-                vm.value = $scope.model.value.alias;
-            } else {
-                vm.value = '';
+            var dataTypeKey = '';
+
+            if ($scope.model.config) {
+                if ($scope.model.config.dataType && $scope.model.config.dataType.Key) {
+                    dataTypeKey = $scope.model.config.dataType.Key;
+                }
+                else if ($scope.model.config.dataTypeKey) {
+                    dataTypeKey = $scope.model.config.dataTypeKey;
+                }
             }
 
-            imageCropPickerResource.GetImageCropsDataForDataType($scope.model.config.dataType.Id)
-                .then(function (data) {
-                    vm.data.cropsData = data;
-                });
+            if (dataTypeKey) {
+                imageCropPickerResource.GetImageCropsDataForDataType(dataTypeKey)
+                    .then(function (data) {
+                        vm.data.cropsData = data;
+                    });
+            }
         };
 
         vm.init();

--- a/src/Our.Umbraco.ImageCropPicker/Web/UI/App_Plugins/ImageCropPicker/Js/ImageCropPicker.resource.js
+++ b/src/Our.Umbraco.ImageCropPicker/Web/UI/App_Plugins/ImageCropPicker/Js/ImageCropPicker.resource.js
@@ -23,10 +23,10 @@
                 "Failed to retrieve data types");
         }
 
-        function getImageCropsDataForDataType(id) {
+        function getImageCropsDataForDataType(dataTypeKey) {
             var config = {
                 params: {
-                    id: id
+                    dataTypeKey: dataTypeKey
                 },
                 headers: { 'Accept': 'application/json' }
             };
@@ -36,4 +36,3 @@
         }
     };
 })();
-

--- a/src/Our.Umbraco.ImageCropPicker/Web/UI/App_Plugins/ImageCropPicker/package.manifest
+++ b/src/Our.Umbraco.ImageCropPicker/Web/UI/App_Plugins/ImageCropPicker/package.manifest
@@ -23,6 +23,9 @@
             ]
           }
         ]
+      },
+      "defaultConfig": {
+        "dataTypeKey": ""
       }
     }
   ],


### PR DESCRIPTION
Added default config for macro usage + removed vm.value as we are getting view value from model.value + update logic for working on data type key + small refactor

Example custom macro configuration:

``` json
{
  "propertyEditors": [
    {
      "alias": "Our.Umbraco.ImageCropPicker.Macro",
      "name": "Image Crop Picker (Macro)",
      "icon": "icon-window-sizes",
      "group": "Image Cropper Extensions",
      "isParameterEditor": true,
      "editor": {
        "view": "~/App_Plugins/ImageCropPicker/Views/CropPicker.html",
        "valueType": "JSON"
      },
      "prevalues": {
        "fields": [
          {
            "label": "Default config data",
            "key": "dataTypeKey",
            "view": "~/App_Plugins/ImageCropPicker/Views/CropPicker.html"
          }
        ]
      },
      "defaultConfig": {
        "dataTypeKey": "1df9f033-e6d4-451f-b8d2-e0cbc50a836f"
      }
    }
  ]
}
```


Example of MacroPartials view

``` csharp
@using Newtonsoft.Json
@using Umbraco.Core.PropertyEditors
@inherits Umbraco.Web.Macros.PartialViewMacroPage
@{
    var imageSizeMacroParameter = Model.MacroParameters["imageSize"];

    if (imageSizeMacroParameter == null
        || (imageSizeMacroParameter != null
            && string.IsNullOrWhiteSpace(imageSizeMacroParameter.ToString())))
    {
        return;
    }

    var imageSize = JsonConvert.DeserializeObject<ImageCropData>(imageSizeMacroParameter.ToString());
}

@(imageSizeMacroParameter.ToString())

<br />

@imageSize.Alias = @imageSize.Width x @imageSize.Height
```
